### PR TITLE
.gitignore: ignore top-level virtual environment directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,8 @@ data
 # ignore documentation for tutorials as it is big
 # (contains notebook output and figures)
 docs/tutorials
+
+# ignore virtual environment directories
+/venv/
+/venv_*/
+/venv-*/


### PR DESCRIPTION
Ignore the top-level directories named `venv`, `venv_*` or `venv-*`, to avoid checking the [virtual environment](https://docs.python.org/3/library/venv.html) directories set up locally.