### PR TITLE
dfu.get_hist_values(): handle incontinuous DataFrame index

### DIFF
--- a/utils/dataframe_utils.py
+++ b/utils/dataframe_utils.py
@@ -212,17 +212,18 @@ def get_hist_values(df, datacolumn='data', xbinscolumn='xbins', ybinscolumn='ybi
         ls = np.zeros(len(df))
         runs = np.zeros(len(df))
         # loop over all entries
-        for i in range(i0, i0 + len(df)):
+        for ii in range(len(df.index)):
+            i = df.index[ii]
             jsonstr = json.loads(preprocess(df.at[i, datacolumn]))
             if has_overflow:
-                vals[i, :][:] = jsonstr
+                vals[ii, :][:] = jsonstr
             else:
                 if dim == 2:
-                    vals[i, 1:-1, 1:-1][:] = jsonstr
+                    vals[ii, 1:-1, 1:-1][:] = jsonstr
                 else:
-                    vals[i, 1:-1] = jsonstr
-            ls[i] = int(df.at[i,lumicolumn])
-            runs[i] = int(df.at[i,runcolumn])
+                    vals[ii, 1:-1] = jsonstr
+            ls[ii] = int(df.at[i,lumicolumn])
+            runs[ii] = int(df.at[i,runcolumn])
     
     # case of numpy array
     if isinstance( df.at[i0, datacolumn], np.ndarray ):


### PR DESCRIPTION
The index of DataFrame rows may become incontinuous after filtering. Such an issue predates #20 and would likely appear when applying the high-stat filters on datasets/MEs with fewer entries.

Reproducer:

```python3
import sys
sys.path.extend(["./src", "./utils"])

from DataLoader import DataLoader
import dataframe_utils as dfu
import hist_utils as hu

loader = DataLoader()
df_legacy_2023 = loader.get_dataframe_from_legacy_file(
    # CSV harvested with dqmiotools
    # from dataset /JetMET0/Run2023D-PromptReco-v1/DQMIO
    # ME JetMET/MET/pfMetPuppi/Cleaned/METSig
    "data/DF_JetMET0-Run2023D-PromptReco-v1_JetMET-MET-pfMet-Cleaned-METSig.csv"
)

df_legacy_filtered = dfu.select_highstat(
    df_legacy_2023,
    entries_to_bins_ratio=10,
)

x_train_legacy_2023 = hu.preparedatafromdf(
    df_legacy_filtered,
    rebinningfactor=1,
    donormalize=True,
    doplot=True
)
```

This patch enables `dataframe_utils.get_hist_values()` to cope with such a situation by looping with the *index of the index* (`ii`) and storing the row with index `i` to `val[ii, ...]` (where `i = df.index[ii]`).