### PR TITLE
treewide: import and use keras backend-agnostically

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 imageio # (Optional) Image-to-GIF conversion
+keras
 matplotlib # Plot generation
 numpy
 pandas
 requests
 six # Python2 and Python3 compatibility
-tensorflow # Machine learning
+tensorflow # (Optional) Keras backend, replaceable with other backends

--- a/src/classifiers/AutoEncoder.py
+++ b/src/classifiers/AutoEncoder.py
@@ -15,8 +15,8 @@
 import os
 import sys
 import numpy as np
-import tensorflow
-from tensorflow.keras.models import load_model
+from keras import Model
+from keras.models import load_model
 import importlib
 
 # local modules
@@ -52,7 +52,7 @@ class AutoEncoder(HistogramClassifier):
             raise Exception('ERROR in AutoEncoder.__init__: model and modelpath cannot both be specified.')
         # case 1: model is specified directly:
         if( model is not None ):
-            if not isinstance( model, tensorflow.keras.Model ):
+            if not isinstance( model, Model ):
                 raise Exception('ERROR in AutoEncoder.init: model has type {}'.format(type(model))
                                +' while a tensorflow model is expected.')
             self.model = model

--- a/src/classifiers/AutoEncoder.py
+++ b/src/classifiers/AutoEncoder.py
@@ -5,7 +5,7 @@
 # 
 # The AutoEncoder derives from the generic HistogramClassifier.  
 # For this specific classifier, the output score of a histogram is the mean-square-error (MSE) between the original histogram and its autoencoder reconstruction.  
-# In essence, it is just a wrapper for a tensorflow model.  
+# In essence, it is just a wrapper for a Keras model.
 
 
 
@@ -29,19 +29,19 @@ import plot_utils
 
 
 class AutoEncoder(HistogramClassifier):
-    ### histogram classfier based on the MSE of an autoencoder reconstruction
+    ### Histogram classfier based on the MSE of an autoencoder reconstruction
     # the AutoEncoder derives from the generic HistogramClassifier. 
     # for this specific classifier, the output score of a histogram is the mean-square-error (MSE) 
     # between the original histogram and its autoencoder reconstruction.
-    # in essence, it is just a wrapper for a tensorflow model.
+    # in essence, it is just a wrapper for a Keras model.
     
     def __init__( self, model=None, modelpath=None ):
-        ### intializer from a tensorflow model
-        # input arguments:
-        # - model: a valid tensorflow model;
+        ### Intializer from a Keras model
+        # Input arguments:
+        # - model: a valid Keras model;
         #          it does not have to be trained already,
         #          the AutoEncoder.train function will take care of this.
-        # - modelpath: path to a stored tensorflow model,
+        # - modelpath: path to a stored Keras model,
         #              it does not have to be trained already,
         #              the AutoEncoder.train function will take care of this.
         # note: model and modelpath are alternative options, they should not both be used simultaneously.
@@ -54,7 +54,7 @@ class AutoEncoder(HistogramClassifier):
         if( model is not None ):
             if not isinstance( model, Model ):
                 raise Exception('ERROR in AutoEncoder.init: model has type {}'.format(type(model))
-                               +' while a tensorflow model is expected.')
+                               +' while a Keras model is expected.')
             self.model = model
         # case 2: model path is specified
         if( modelpath is not None ):
@@ -63,8 +63,8 @@ class AutoEncoder(HistogramClassifier):
             self.model = load_model(modelpath,custom_objects={'mseTop10':mseTop10})
         
     def train( self, histograms, doplot=True, epochs=10, batch_size=500, shuffle=False, verbose=1, validation_split=0.1, **kwargs ):
-        ### train the model on a given set of input histograms
-        # input arguments:
+        ### Train the model on a given set of input histograms
+        # Input arguments:
         # - histograms: set of training histograms, a numpy array of shape (nhistograms,nbins)
         # - doplot: boolean whether to make a plot of the loss value
         # - others: see the keras fit function
@@ -77,25 +77,33 @@ class AutoEncoder(HistogramClassifier):
         if doplot: plot_utils.plot_loss(history)
         
     def evaluate( self, histograms ):
-        ### classification of a collection of histograms based on their autoencoder reconstruction
+        ### Classification of a collection of histograms based on their autoencoder reconstruction
         super( AutoEncoder,self ).evaluate( histograms )
         predictions = self.model.predict( histograms )
         return mseTop10Raw( histograms, predictions )
     
     def reconstruct( self, histograms ):
-        ### return the autoencoder reconstruction of a set of histograms
+        ### Return the autoencoder reconstruction of a set of histograms
         return self.model.predict( histograms )
     
     def save( self, path ):
-        ### save the underlying tensorflow model to a tensorflow SavedModel or H5 format.
-        # note: depending on the extension specified in path, the SavedModel or H5 format is chosen,
-        #       see https://www.tensorflow.org/guide/keras/save_and_serialize
+        ### save the underlying Keras model.
+        # note:
+        # - The saving format is determined from the file extension specified in `path`.
+        # - The only (cross-backend) supported format for Keras 3 is the "Keras v3", using the ".keras" extension.
+        # - For Keras 2 and the TensorFlow backend, the "TensorFlow SavedModel" format is chosen when the extension is ".keras".
+        # - When the extension is ".h5" or ".hdf5", the HDF5 format is chosen.
+        #   The HDF5 format support predates the "TensorFlow SavedModel", but is considered legacy in Keras 3.
+        # - See also:
+        #     - https://keras.io/guides/serialization_and_saving/
+        #     - https://www.tensorflow.org/guide/keras/save_and_serialize
+        #     - https://github.com/keras-team/keras/blob/v3.11.3/keras/src/saving/saving_api.py#L19
         super( AutoEncoder,self ).save( path )
         self.model.save( path )
         
     @classmethod
     def load( self, path, **kwargs ):
-        ### get an AutoEncoder instance from a saved tensorflow SavedModel or H5 file
+        ### get an AutoEncoder instance from a saved Keras model file
         super( AutoEncoder,self ).load( path )
         model = load_model(path, custom_objects={'mseTop10':mseTop10}, **kwargs)
         # to do: check if the above also works if mseTop10 is not in the model

--- a/tutorials/autoencoder_1d.ipynb
+++ b/tutorials/autoencoder_1d.ipynb
@@ -30,7 +30,6 @@
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "from keras import backend as K\n",
-    "import tensorflow as tf\n",
     "from keras.models import load_model\n",
     "\n",
     "# local modules\n",

--- a/tutorials/autoencoder_1d.ipynb
+++ b/tutorials/autoencoder_1d.ipynb
@@ -31,7 +31,7 @@
     "import matplotlib.pyplot as plt\n",
     "from keras import backend as K\n",
     "import tensorflow as tf\n",
-    "from tensorflow.keras.models import load_model\n",
+    "from keras.models import load_model\n",
     "\n",
     "# local modules\n",
     "sys.path.append('../utils')\n",

--- a/utils/autoencoder_utils.py
+++ b/utils/autoencoder_utils.py
@@ -381,10 +381,9 @@ def getautoencoder(input_size,arch,act=[],opt='adam',loss=mseTop10):
     
     import math
     import tensorflow as tf
-    from tensorflow import keras
-    from tensorflow.keras.callbacks import ModelCheckpoint, EarlyStopping
-    from tensorflow.keras.layers import Input, Dense
-    from tensorflow.keras.models import Model, Sequential, load_model
+    from keras.callbacks import ModelCheckpoint, EarlyStopping
+    from keras.layers import Input, Dense
+    from keras.models import Model, Sequential, load_model
     from keras import backend as K
     
     if len(act)==0: act = ['tanh']*len(arch)

--- a/utils/autoencoder_utils.py
+++ b/utils/autoencoder_utils.py
@@ -14,7 +14,15 @@
 # external modules
 import numpy as np
 import tensorflow as tf
-from keras import backend as K
+import keras
+
+# keras math operation module
+if keras.__version__.startswith("2."):
+    from keras import backend as ops
+else:
+    # Since Keras 3, mathematical operation functions are moved under keras.ops.
+    from keras import ops
+
 import seaborn as sn
 import pandas as pd
 import matplotlib.pyplot as plt
@@ -37,8 +45,8 @@ def mseTop10(y_true, y_pred):
     # - mean squared error between y_true and y_pred,
     #   where only the 10 bins with largest squared error are taken into account.
     #   if y_true and y_pred are 2D arrays, this function returns 1D array (mseTop10 for each histogram)
-    top_values, _ = tf.nn.top_k(K.square(y_pred - y_true), k=10, sorted=True)
-    mean=K.mean(top_values, axis=-1)
+    top_values, _ = tf.nn.top_k(ops.square(y_pred - y_true), k=10, sorted=True)
+    mean=ops.mean(top_values, axis=-1)
     return mean
 
 def mseTop10Raw(y_true, y_pred):
@@ -79,8 +87,8 @@ def chiSquared(y_true, y_pred):
     # output:
     # - relative mean squared error between y_true and y_pred,
     #   if y_true and y_pred are 2D arrays, this function returns 1D array (chiSquared for each histogram)
-    normdiffsq = np.divide(K.square(y_pred - y_true),y_true)
-    chi2 = K.sum(normdiffsq,axis=-1)
+    normdiffsq = np.divide(ops.square(y_pred - y_true),y_true)
+    chi2 = ops.sum(normdiffsq,axis=-1)
     return chi2
 
 def chiSquaredTopNRaw(y_true, y_pred, n=10):

--- a/utils/autoencoder_utils.py
+++ b/utils/autoencoder_utils.py
@@ -29,7 +29,7 @@ else:
     # Since Keras 3, mathematical operation functions are moved under keras.ops.
     from keras import ops
 
-import seaborn as sn
+# import seaborn as sn
 import pandas as pd
 import matplotlib.pyplot as plt
 import importlib

--- a/utils/autoencoder_utils.py
+++ b/utils/autoencoder_utils.py
@@ -11,10 +11,17 @@
 
 ### imports
 
+import math
+
 # external modules
 import numpy as np
 import tensorflow as tf
 import keras
+
+from keras.callbacks import ModelCheckpoint, EarlyStopping
+from keras.layers import Input, Dense
+from keras.models import Model, Sequential, load_model
+from keras import backend as K
 
 # keras math operation module
 if keras.__version__.startswith("2."):
@@ -386,13 +393,6 @@ def getautoencoder(input_size,arch,act=[],opt='adam',loss=mseTop10):
     # - act: list of activations per layer (default: tanh)
     # - opt: optimizer to use (default: adam)
     # - loss: loss function to use (defualt: mseTop10)
-    
-    import math
-    import tensorflow as tf
-    from keras.callbacks import ModelCheckpoint, EarlyStopping
-    from keras.layers import Input, Dense
-    from keras.models import Model, Sequential, load_model
-    from keras import backend as K
     
     if len(act)==0: act = ['tanh']*len(arch)
     layers = []

--- a/utils/autoencoder_utils.py
+++ b/utils/autoencoder_utils.py
@@ -15,7 +15,6 @@ import math
 
 # external modules
 import numpy as np
-import tensorflow as tf
 import keras
 
 from keras.callbacks import ModelCheckpoint, EarlyStopping
@@ -52,7 +51,11 @@ def mseTop10(y_true, y_pred):
     # - mean squared error between y_true and y_pred,
     #   where only the 10 bins with largest squared error are taken into account.
     #   if y_true and y_pred are 2D arrays, this function returns 1D array (mseTop10 for each histogram)
-    top_values, _ = tf.nn.top_k(ops.square(y_pred - y_true), k=10, sorted=True)
+    if keras.__version__.startswith("2."):
+        top_k = K.tf.math.top_k
+    else:
+        top_k = ops.top_k
+    top_values, _ = top_k(ops.square(y_pred - y_true), k=10, sorted=True)
     mean=ops.mean(top_values, axis=-1)
     return mean
 


### PR DESCRIPTION
Keras 1 and 3 are multi-backend machine-learning interface, while Keras 2 supports only TensorFlow.

Let's import `keras` directly instead of `tf.keras` and adhere to the Keras API to make the codebase compatible to Keras 3 and other backends, while preserving backward compatibility to Keras 2.