### PR TITLE
plot_utils, autoencoder_utils: miscelaneous arguments/return value improvement

### DIFF
--- a/utils/autoencoder_utils.py
+++ b/utils/autoencoder_utils.py
@@ -305,7 +305,7 @@ def get_confusion_matrix_from_hists(hists, labels, predicted_hists, msewp=None):
     
     # get mse
     mse = mseTop10Raw(hists, predicted_hists)
-    get_confusion_matrix(mse, labels, wp=msewp)
+    return get_confusion_matrix(mse, labels, wp=msewp)
 
 
 

--- a/utils/plot_utils.py
+++ b/utils/plot_utils.py
@@ -694,8 +694,8 @@ def plot_score_dist_multi( scores, labels=None, colors=None, fig=None, ax=None,
     if colors is None:
         colors = ['b']*len(scores)
     # make the x-axis
-    minscore = min( *[np.amin(score_array) for score_array in scores] )
-    maxscore = max( *[np.amax(score_array) for score_array in scores] )
+    minscore = min( np.amin(score_array) for score_array in scores )
+    maxscore = max( np.amax(score_array) for score_array in scores )
     scorebins = np.linspace(minscore,maxscore,num=nbins+1)
     scoreax = (scorebins[1:] + scorebins[:-1])/2
     # make the histograms


### PR DESCRIPTION
* Fix `plot_utils.plot_score_dist_multi()` when `scores` contains only one element.
* Make `autoencoder_utils.get_confusion_matrix_from_hists()` return `(wp, fig, ax)` as `autoencoder_utils.get_confusion_matrix()` does.